### PR TITLE
Add build script and Flutter WebView app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Nova-SMP
+# Nova SMP
+
+This repository contains the source for a simple Flutter application that wraps the website [https://nova.cube-kingdom.de](https://nova.cube-kingdom.de) in a WebView. The app name is **Nova SMP** and it uses `icon.png` as its launcher icon.
+
+## Building
+
+Execute the `build.sh` script on an Ubuntu server to install all dependencies, fetch the Flutter SDK, generate platform files and build release binaries for Android and (if the host supports it) iOS:
+
+```bash
+bash build.sh
+```
+
+The Android APK will be placed in `nova_smp_app/build/app/outputs/flutter-apk/`. Building the iOS app requires macOS with Xcode; on other systems the script will skip that step.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+APP_DIR="nova_smp_app"
+PACKAGE_ID="com.plsreload9383.novasmp"
+APP_NAME="Nova SMP"
+URL="https://nova.cube-kingdom.de"
+FLUTTER_VERSION=3.22.1
+
+# Install dependencies
+sudo apt-get update
+sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa default-jdk build-essential || true
+
+# Install Flutter SDK if not present
+if [ ! -d flutter-sdk ]; then
+  git clone https://github.com/flutter/flutter.git -b ${FLUTTER_VERSION} flutter-sdk
+fi
+export PATH="$PWD/flutter-sdk/bin:$PATH"
+
+# Create project if not exists
+if [ ! -d "$APP_DIR" ]; then
+  flutter create --platforms=android,ios --org com.plsreload9383 ${APP_DIR}
+  (cd ${APP_DIR} && rm -rf lib pubspec.yaml)
+  cp -r lib ${APP_DIR}/lib
+  cp pubspec.yaml ${APP_DIR}/pubspec.yaml
+  cp icon.png ${APP_DIR}/icon.png
+fi
+
+cd ${APP_DIR}
+
+# Ensure correct package id in android
+perl -0 -i -pe "s/applicationId \"[^"]*\"/applicationId \"${PACKAGE_ID}\"/" android/app/build.gradle
+perl -0 -i -pe "s/android:label=\"[^\"]*\"/android:label=\"${APP_NAME}\"/" android/app/src/main/AndroidManifest.xml
+
+# Ensure iOS bundle identifier and name
+if [ -f ios/Runner.xcodeproj/project.pbxproj ]; then
+  perl -0 -i -pe "s/PRODUCT_BUNDLE_IDENTIFIER = [^;]*;/PRODUCT_BUNDLE_IDENTIFIER = ${PACKAGE_ID};/" ios/Runner.xcodeproj/project.pbxproj || true
+  perl -0 -i -pe "s/CFBundleName\"\>[^<]*\<\/string\>/CFBundleName\">${APP_NAME}<\/string>/" ios/Runner/Info.plist || true
+fi
+
+flutter pub get
+flutter pub run flutter_launcher_icons:main
+
+# Build Android APK
+flutter build apk --release
+
+# Attempt to build iOS (will fail on non-macOS but we attempt)
+flutter build ios --release --no-codesign || echo "iOS build requires macOS with Xcode"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+void main() {
+  runApp(const NovaApp());
+}
+
+class NovaApp extends StatelessWidget {
+  const NovaApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'Nova SMP',
+      home: WebViewApp(),
+    );
+  }
+}
+
+class WebViewApp extends StatefulWidget {
+  const WebViewApp({super.key});
+
+  @override
+  State<WebViewApp> createState() => _WebViewAppState();
+}
+
+class _WebViewAppState extends State<WebViewApp> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: SafeArea(
+        child: WebView(
+          initialUrl: 'https://nova.cube-kingdom.de',
+          javascriptMode: JavascriptMode.unrestricted,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,25 @@
+name: nova_smp
+description: Nova SMP
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  webview_flutter: ^4.2.4
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_launcher_icons: ^0.13.1
+
+flutter:
+  uses-material-design: true
+
+flutter_icons:
+  android: true
+  ios: true
+  image_path: "icon.png"


### PR DESCRIPTION
## Summary
- add Flutter WebView app that loads https://nova.cube-kingdom.de
- configure dependencies and launcher icons in pubspec
- provide build.sh script to install Flutter and build Android/iOS apps

## Testing
- `bash build.sh` *(fails: resolving deltas ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b9fd37f0883248bfe501ceb72cced